### PR TITLE
Fix repository URL and update publishConfig access

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -2,7 +2,7 @@
   "name": "@openflam/dnsspatialdiscovery",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/openflam/dns-spatial-discovery.git.git"
+    "url": "git+https://github.com/openflam/dns-spatial-discovery.git"
   },
   "version": "4.4.4",
   "description": "Using the DNS to disocvery localization servers based on location",
@@ -35,6 +35,6 @@
     "axios": "^1.7.2"
   },
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com"
+    "access": "public"
   }
 }


### PR DESCRIPTION
This should allow direct install by `@openflam/dnsspatialdiscovery` without having to specify the repo url

Having it the current `"https://npm.pkg.github.com"` would work for non-public/private package via git login